### PR TITLE
Add custom notation and API endpoint for fetching entries by title

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -3,5 +3,5 @@
 @import 'tailwindcss/utilities';
 
 .entry-not-found {
-    color: #666666;
+	color: #666666;
 }

--- a/src/app.css
+++ b/src/app.css
@@ -1,3 +1,7 @@
 @import 'tailwindcss/base';
 @import 'tailwindcss/components';
 @import 'tailwindcss/utilities';
+
+.entry-not-found {
+    color: #666666;
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -129,7 +129,25 @@ export class AdminEntryRepository {
 }
 
 export class PublicEntryRepository {
-	static async getEntry(path: string): Promise<Entry> {
+	static async getEntryByTitle(title: string): Promise<Entry | null> {
+		try {
+			const [rows] = await db.query<Entry[] & RowDataPacket[]>(
+				`SELECT * FROM entry
+				WHERE title = ?
+				    AND status='published'`,
+				[title]
+			);
+			if (rows.length === 0) {
+				return null;
+			}
+			return rows[0];
+		} catch (error) {
+			console.error(`Error fetching entry: ${error} title=${title}`);
+			throw error;
+		}
+	}
+
+	static async getEntry(path: string): Promise<Entry | null> {
 		try {
 			const [rows] = await db.query<Entry[] & RowDataPacket[]>(
 				`SELECT * FROM entry
@@ -138,7 +156,7 @@ export class PublicEntryRepository {
 				[path]
 			);
 			if (rows.length === 0) {
-				throw new Error('Entry not found');
+				return null;
 			}
 			return rows[0];
 		} catch (error) {

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -9,15 +9,19 @@ function entryLinkPlugin(md: MarkdownIt) {
 		const max = state.posMax;
 
 		// [[ の検出
-		if (state.src.charCodeAt(start) !== 0x5B /* [ */ ||
-			state.src.charCodeAt(start + 1) !== 0x5B /* [ */) {
+		if (
+			state.src.charCodeAt(start) !== 0x5b /* [ */ ||
+			state.src.charCodeAt(start + 1) !== 0x5b /* [ */
+		) {
 			return false;
 		}
 
 		let end = start + 2;
 		while (end < max) {
-			if (state.src.charCodeAt(end) === 0x5D /* ] */ &&
-				state.src.charCodeAt(end + 1) === 0x5D /* ] */) {
+			if (
+				state.src.charCodeAt(end) === 0x5d /* ] */ &&
+				state.src.charCodeAt(end + 1) === 0x5d /* ] */
+			) {
 				break;
 			}
 			end++;
@@ -32,7 +36,10 @@ function entryLinkPlugin(md: MarkdownIt) {
 		if (!silent) {
 			const content = state.src.slice(start + 2, end);
 			const token = state.push('entry_link', 'a', 0);
-			token.attrs = [['class', 'entry-link'], ['data-title', content]];
+			token.attrs = [
+				['class', 'entry-link'],
+				['data-title', content]
+			];
 			token.content = content;
 			token.markup = '[[';
 			token.info = '';

--- a/src/routes/api/entry/by-title/[title]/+server.ts
+++ b/src/routes/api/entry/by-title/[title]/+server.ts
@@ -1,0 +1,21 @@
+import type { RequestHandler } from '@sveltejs/kit';
+import { PublicEntryRepository } from '$lib/db';
+
+export const GET: RequestHandler = async ({ params }) => {
+	const title = params.title;
+	if (!title) {
+		return new Response(JSON.stringify({ error: 'Missing title' }), { status: 400 });
+	}
+
+	try {
+		const entry = await PublicEntryRepository.getEntryByTitle(title);
+        if (entry === null) {
+            return new Response(JSON.stringify({ error: 'Entry not found' }), { status: 404 });
+        } else {
+            return new Response(JSON.stringify(entry), { status: 200 });
+        }
+	} catch (error) {
+		console.error(error);
+		return new Response(JSON.stringify({ error: 'Database error' }), { status: 500 });
+	}
+};

--- a/src/routes/api/entry/by-title/[title]/+server.ts
+++ b/src/routes/api/entry/by-title/[title]/+server.ts
@@ -9,11 +9,11 @@ export const GET: RequestHandler = async ({ params }) => {
 
 	try {
 		const entry = await PublicEntryRepository.getEntryByTitle(title);
-        if (entry === null) {
-            return new Response(JSON.stringify({ error: 'Entry not found' }), { status: 404 });
-        } else {
-            return new Response(JSON.stringify(entry), { status: 200 });
-        }
+		if (entry === null) {
+			return new Response(JSON.stringify({ error: 'Entry not found' }), { status: 404 });
+		} else {
+			return new Response(JSON.stringify(entry), { status: 200 });
+		}
 	} catch (error) {
 		console.error(error);
 		return new Response(JSON.stringify({ error: 'Database error' }), { status: 500 });

--- a/src/routes/entry/[...slug]/+page.server.ts
+++ b/src/routes/entry/[...slug]/+page.server.ts
@@ -1,3 +1,4 @@
+import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import { PublicEntryRepository } from '$lib/db';
 import { renderHTMLByEntry } from '$lib/markdown';
@@ -7,6 +8,12 @@ export const load: PageServerLoad = async (params) => {
 	const path = params.params.slug;
 
 	const entry = await PublicEntryRepository.getEntry(path);
+
+	if (entry === null) {
+		error(404, {
+			message: 'Not found'
+		});
+	}
 
 	return {
 		entry,

--- a/src/routes/entry/[...slug]/+page.svelte
+++ b/src/routes/entry/[...slug]/+page.svelte
@@ -1,8 +1,55 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import type { PageData } from './$types';
 	import 'highlight.js/styles/github.css';
 
 	export let data: PageData;
+
+	onMount(
+		() => {
+			const links = document.querySelectorAll('.entry-link');
+			links.forEach(link => {
+				link.addEventListener('click', handleEntryLinkClick);
+			});
+
+			// クリーンアップ処理
+			return () => {
+				links.forEach(link => {
+					link.removeEventListener('click', handleEntryLinkClick);
+				});
+			};
+		}
+	)
+
+	function handleEntryLinkClick(event: MouseEvent) {
+		event.preventDefault();
+
+		const target = event.target as HTMLElement | null;
+		if (target && target instanceof HTMLElement) {
+			const link = target.closest('.entry-link') as HTMLAnchorElement | null;
+			console.log(`Entry link clicked: ${link}`);
+
+			if (link) {
+				const title = link.dataset.title; // data-title 属性から取得
+				console.log(`Entry link clicked: ${title}`);
+
+				// API 呼び出しなどの処理をここで実行
+				fetch(`/api/entry/by-title/${encodeURIComponent(title)}`)
+					.then(response => response.json())
+					.then(data => {
+						console.log('Fetched entry data:', data);
+					})
+					.catch(err => {
+						console.error('Error fetching entry data:', err);
+					});
+			} else {
+				console.warn('No .entry-link element found');
+			}
+		} else {
+			console.warn('Event target is not an HTML element');
+		}
+
+	}
 </script>
 
 <svelte:head>

--- a/src/routes/entry/[...slug]/+page.svelte
+++ b/src/routes/entry/[...slug]/+page.svelte
@@ -7,14 +7,14 @@
 
 	onMount(() => {
 		const links = document.querySelectorAll('.entry-link');
-		links.forEach((link) => {
-			link.addEventListener('click', handleEntryLinkClick);
+		links.forEach((link: Element) => {
+			(link as HTMLElement).addEventListener('click', handleEntryLinkClick);
 		});
 
 		// クリーンアップ処理
 		return () => {
 			links.forEach((link) => {
-				link.removeEventListener('click', handleEntryLinkClick);
+				(link as HTMLElement).removeEventListener('click', handleEntryLinkClick);
 			});
 		};
 	});

--- a/src/routes/entry/[...slug]/+page.svelte
+++ b/src/routes/entry/[...slug]/+page.svelte
@@ -27,17 +27,30 @@
 		const target = event.target as HTMLElement | null;
 		if (target && target instanceof HTMLElement) {
 			const link = target.closest('.entry-link') as HTMLAnchorElement | null;
-			console.log(`Entry link clicked: ${link}`);
 
 			if (link) {
 				const title = link.dataset.title; // data-title 属性から取得
-				console.log(`Entry link clicked: ${title}`);
+				if (!title) {
+					console.warn('No data-title attribute found');
+					return;
+				}
+
+				console.log(`Entry link clicked: '${title}'`);
 
 				// API 呼び出しなどの処理をここで実行
 				fetch(`/api/entry/by-title/${encodeURIComponent(title)}`)
-					.then(response => response.json())
-					.then(data => {
-						console.log('Fetched entry data:', data);
+					.then(async response => {
+						if (response.status === 404) {
+							link.classList.add('entry-not-found');
+						} else {
+							const data = await response.json();
+							const path = data.path;
+							if (path) {
+								window.location.href = `/entry/${path}`;
+							} else {
+								console.error('No path found in response data');
+							}
+						}
 					})
 					.catch(err => {
 						console.error('Error fetching entry data:', err);

--- a/src/routes/entry/[...slug]/+page.svelte
+++ b/src/routes/entry/[...slug]/+page.svelte
@@ -5,21 +5,19 @@
 
 	export let data: PageData;
 
-	onMount(
-		() => {
-			const links = document.querySelectorAll('.entry-link');
-			links.forEach(link => {
-				link.addEventListener('click', handleEntryLinkClick);
-			});
+	onMount(() => {
+		const links = document.querySelectorAll('.entry-link');
+		links.forEach((link) => {
+			link.addEventListener('click', handleEntryLinkClick);
+		});
 
-			// クリーンアップ処理
-			return () => {
-				links.forEach(link => {
-					link.removeEventListener('click', handleEntryLinkClick);
-				});
-			};
-		}
-	)
+		// クリーンアップ処理
+		return () => {
+			links.forEach((link) => {
+				link.removeEventListener('click', handleEntryLinkClick);
+			});
+		};
+	});
 
 	function handleEntryLinkClick(event: MouseEvent) {
 		event.preventDefault();
@@ -39,7 +37,7 @@
 
 				// API 呼び出しなどの処理をここで実行
 				fetch(`/api/entry/by-title/${encodeURIComponent(title)}`)
-					.then(async response => {
+					.then(async (response) => {
 						if (response.status === 404) {
 							link.classList.add('entry-not-found');
 						} else {
@@ -52,7 +50,7 @@
 							}
 						}
 					})
-					.catch(err => {
+					.catch((err) => {
 						console.error('Error fetching entry data:', err);
 					});
 			} else {
@@ -61,7 +59,6 @@
 		} else {
 			console.warn('Event target is not an HTML element');
 		}
-
 	}
 </script>
 


### PR DESCRIPTION
Introduce a custom notation for entry links and implement an API endpoint to fetch entries by title, enhancing error handling for missing entries.