### PR TITLE
Refactor entry schema: replace status with visibility

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -1,10 +1,82 @@
-create table entry (
-                       title varchar(255),
-                       path varchar(255),
-                       body longtext,
-                       status varchar(255),
-                       format varchar(255) default 'mkdn',
-                       createdAt datetime DEFAULT CURRENT_TIMESTAMP,
-                       updatedAt datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-                       primary key (path)
-) engine=innodb default charset=utf8mb4;
+-- Current schema:
+CREATE TABLE "entry" (
+  "path" varchar(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
+  "title" varchar(300) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+  "body" text CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+  "status" enum('draft','published') NOT NULL,
+  "format" enum('html','mkdn') NOT NULL DEFAULT 'mkdn',
+  "created_at" datetime DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" datetime DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY ("path"),
+  KEY "created_at" ("created_at"),
+  KEY "updated_at" ("updated_at"),
+  FULLTEXT KEY "idx_bigram" ("title","body") /*!50100 WITH PARSER "ngram" */
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- mysqldump -u root -p --databases blog > schema.sql
+
+-- check the table:
+select status, count(*) from entry group by status;
+
+-- mysql> select status, count(*) from entry group by status;
+-- +-----------+----------+
+-- | status    | count(*) |
+-- +-----------+----------+
+-- | published |     1587 |
+-- | draft     |       44 |
+-- +-----------+----------+
+-- 2 rows in set (0.09 sec)
+
+-- add a new column to the table:
+ALTER TABLE entry ADD COLUMN visibility ENUM('public', 'private') DEFAULT 'private' AFTER status;
+
+-- Update the visibility column based on the status column:
+UPDATE entry
+SET visibility = CASE
+    WHEN status = 'published' THEN 'public'
+    ELSE 'private'
+END;
+
+-- Check the counts of each status and visibility:
+select status, count(*) from entry group by status;
+select visibility, count(*) from entry group by visibility;
+
+
+-- mysql> select status, count(*) from entry group by status;
+-- +-----------+----------+
+-- | status    | count(*) |
+-- +-----------+----------+
+-- | published |     1587 |
+-- | draft     |       44 |
+-- +-----------+----------+
+-- 2 rows in set (0.09 sec)
+
+-- mysql> select visibility, count(*) from entry group by visibility;
+-- +------------+----------+
+-- | visibility | count(*) |
+-- +------------+----------+
+-- | public     |     1587 |
+-- | private    |       44 |
+-- +------------+----------+
+-- 2 rows in set (0.09 sec)
+
+-- Now we can make the visibility column NOT NULL:
+ALTER TABLE entry MODIFY COLUMN visibility ENUM('public', 'private') NOT NULL DEFAULT 'private';
+
+-- Use visibility instead of status in the PublicEntryRepository and AdminEntryRepository
+-- Deploy to the production server
+
+-- Now we can drop the status column:
+ALTER TABLE entry DROP COLUMN status;
+
+-- Finally, we can drop the status column:
+CREATE TABLE entry (
+    title VARCHAR(255),
+    path VARCHAR(255),
+    body LONGTEXT,
+    visibility ENUM('public', 'private') NOT NULL DEFAULT 'private',
+    format VARCHAR(255) DEFAULT 'mkdn',
+    createdAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updatedAt DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (path)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -33,7 +33,7 @@ export type Entry = {
 	path: string;
 	title: string;
 	body: string;
-	status: 'draft' | 'published';
+	visibility: 'private' | 'public';
 	format: 'html' | 'mkdn';
 	created_at: string;
 	updated_at: string | null;

--- a/src/lib/repository/AdminEntryRepository.ts
+++ b/src/lib/repository/AdminEntryRepository.ts
@@ -25,7 +25,12 @@ export class AdminEntryRepository {
 	 */
 	async updateEntry(
 		path: string,
-		data: { title: string; body: string; status: 'draft' | 'published'; updated_at: string | null }
+		data: {
+			title: string;
+			body: string;
+			visibility: 'private' | 'public';
+			updated_at: string | null;
+		}
 	): Promise<Entry> {
 		// updated_at is only for optimistic concurrency control
 
@@ -33,10 +38,10 @@ export class AdminEntryRepository {
 		const [result] = await db.query<ResultSetHeader>(
 			`
 			UPDATE entry
-			SET title = ?, body = ?, status = ?
+			SET title = ?, body = ?, visibility = ?
 			WHERE path = ? AND (updated_at = ? OR (updated_at IS NULL AND ? IS NULL))
 			`,
-			[data.title, data.body, data.status, path, data.updated_at, data.updated_at]
+			[data.title, data.body, data.visibility, path, data.updated_at, data.updated_at]
 		);
 
 		// 更新が成功したかをチェック
@@ -75,7 +80,7 @@ export class AdminEntryRepository {
 	async createEntry(data: {
 		title: string;
 		body: string;
-		status: 'draft' | 'published';
+		visibility: 'private' | 'public';
 	}): Promise<string> {
 		const pathFormatter = 'yyyy/MM/dd/HHmmss';
 		const path = format(new Date(), pathFormatter);
@@ -83,10 +88,10 @@ export class AdminEntryRepository {
 		// エントリ作成クエリ
 		await db.query(
 			`
-	  INSERT INTO entry (path, title, body, status)
+	  INSERT INTO entry (path, title, body, visibility)
 	  VALUES (?, ?, ?, ?)
 	  `,
-			[path, data.title, data.body, data.status]
+			[path, data.title, data.body, data.visibility]
 		);
 
 		return path;

--- a/src/lib/repository/PublicEntryRepository.ts
+++ b/src/lib/repository/PublicEntryRepository.ts
@@ -7,7 +7,7 @@ export class PublicEntryRepository {
 			const [rows] = await db.query<Entry[] & RowDataPacket[]>(
 				`SELECT * FROM entry
 				WHERE title = ?
-				    AND status='published'`,
+				    AND visibility='public'`,
 				[title]
 			);
 			if (rows.length === 0) {
@@ -25,7 +25,7 @@ export class PublicEntryRepository {
 			const [rows] = await db.query<Entry[] & RowDataPacket[]>(
 				`SELECT * FROM entry
 				WHERE path = ?
-				    AND status='published'`,
+				    AND visibility='public'`,
 				[path]
 			);
 			if (rows.length === 0) {
@@ -62,7 +62,7 @@ export class PublicEntryRepository {
 		const [entries] = await db.query<Entry[] & RowDataPacket[]>(
 			`
 			SELECT * FROM entry
-			WHERE status = 'published'
+			WHERE visibility = 'public'
 			ORDER BY path DESC
 			LIMIT ? OFFSET ?
 			`,

--- a/src/routes/admin/EntryList.svelte
+++ b/src/routes/admin/EntryList.svelte
@@ -7,7 +7,7 @@
 <div class="list">
 	{#each entries as entry}
 		<a
-			class="item {entry.status === 'draft' ? 'draft' : ''}"
+			class="item {entry.visibility === 'private' ? 'private' : ''}"
 			href={`/admin/entry/${encodeURIComponent(entry.path)}`}
 		>
 			<h2 class="title">{entry.title}</h2>
@@ -31,7 +31,7 @@
 		box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 	}
 
-	.item.draft {
+	.item.private {
 		background-color: #e5e7eb;
 	}
 

--- a/src/routes/admin/api/entry/+server.ts
+++ b/src/routes/admin/api/entry/+server.ts
@@ -23,16 +23,16 @@ export const POST: RequestHandler = async ({ locals, request }) => {
 
 		const title = req.title;
 		const body = req.body;
-		const status = req.status;
+		const visibility = req.visibility;
 
-		if (!title || !body || !status) {
+		if (!title || !body || !visibility) {
 			return new Response(JSON.stringify({ error: 'Missing required fields' }), { status: 400 });
 		}
 
 		const path = await locals.adminEntryRepository.createEntry({
 			title,
 			body,
-			status
+			visibility
 		});
 		return new Response(
 			JSON.stringify({

--- a/src/routes/admin/api/entry/[...slug]/+server.ts
+++ b/src/routes/admin/api/entry/[...slug]/+server.ts
@@ -15,13 +15,13 @@ export const POST: RequestHandler = async ({ locals, params, request }) => {
 
 		const title = req.title;
 		const body = req.body;
-		const status = req.status;
+		const visibility = req.visibility;
 		const updated_at = req.updated_at;
 
 		const entry = await locals.adminEntryRepository.updateEntry(path, {
 			title,
 			body,
-			status,
+			visibility,
 			updated_at
 		});
 		return new Response(JSON.stringify(entry), { status: 200 });

--- a/src/routes/admin/entry/[path]/+page.svelte
+++ b/src/routes/admin/entry/[path]/+page.svelte
@@ -15,7 +15,7 @@
 	let entry: Entry = data.entry;
 	let title: string = $state(entry.title);
 	let body: string = $state(entry.body); // 初期値として本文を保持
-	let status: 'draft' | 'published' = $state(entry.status);
+	let visibility: 'private' | 'public' = $state(entry.visibility);
 
 	let successMessage = $state('');
 	let errorMessage = $state('');
@@ -50,7 +50,7 @@
 			const request = {
 				title,
 				body,
-				status,
+				visibility: visibility,
 				updated_at: entry.updated_at
 			};
 			const response = await fetch('/admin/api/entry/' + entry.path, {
@@ -128,10 +128,16 @@
 	</div>
 
 	<div>
-		<label for="status" class="label">Status</label>
-		<select id="status" name="status" class="select" bind:value={status} onchange={handleInput}>
-			<option value="draft">Draft</option>
-			<option value="published">Published</option>
+		<label for="visibility" class="label">Visibility</label>
+		<select
+			id="visibility"
+			name="visibility"
+			class="select"
+			bind:value={visibility}
+			onchange={handleInput}
+		>
+			<option value="private">Private</option>
+			<option value="public">Public</option>
 		</select>
 	</div>
 
@@ -140,7 +146,7 @@
 	</div>
 
 	<!-- link to the user side page -->
-	{#if status === 'published'}
+	{#if visibility === 'public'}
 		<div class="link-container">
 			<a href="/entry/{entry.path}" class="link">Go to User Side Page</a>
 		</div>

--- a/src/routes/admin/entry/create/+page.svelte
+++ b/src/routes/admin/entry/create/+page.svelte
@@ -5,7 +5,7 @@
 
 	let title: string = '';
 	let body: string = '';
-	let status: 'draft' | 'published' = 'draft';
+	let visibility: 'private' | 'public' = 'private';
 
 	function handleSubmit(event: Event) {
 		event.preventDefault();
@@ -13,7 +13,7 @@
 		const data = {
 			title,
 			body,
-			status
+			visibility
 		};
 
 		fetch('/admin/api/entry', {
@@ -61,10 +61,10 @@
 	</div>
 
 	<div>
-		<label for="status" class="label">Status</label>
-		<select id="status" name="status" class="select" bind:value={status}>
-			<option value="draft">Draft</option>
-			<option value="published">Published</option>
+		<label for="visibility" class="label">Visibility</label>
+		<select id="visibility" name="visibility" class="select" bind:value={visibility}>
+			<option value="private">Private</option>
+			<option value="public">Public</option>
 		</select>
 	</div>
 


### PR DESCRIPTION
Replace the status column in the entry schema with a visibility column, updating related queries and repository logic accordingly. This change enhances clarity in the data model by distinguishing between entry visibility and status.