### PR TITLE
Implement autocompletion for internal links in Markdown editor

### DIFF
--- a/src/lib/repository/AdminEntryRepository.ts
+++ b/src/lib/repository/AdminEntryRepository.ts
@@ -407,6 +407,16 @@ export class AdminEntryRepository {
 		);
 		return rows;
 	}
+
+	async getTitles(): Promise<string[]> {
+		const [rows] = await db.query<RowDataPacket[]>(
+			`
+			SELECT title
+			FROM entry
+			`
+		);
+		return rows.map((it) => it.title);
+	}
 }
 
 export type HasDestTitle = {

--- a/src/routes/admin/api/entry/title/+server.ts
+++ b/src/routes/admin/api/entry/title/+server.ts
@@ -1,0 +1,11 @@
+import type { RequestHandler } from '@sveltejs/kit';
+
+export const GET: RequestHandler = async ({ locals }) => {
+	try {
+		const titles = await locals.adminEntryRepository.getTitles();
+		return new Response(JSON.stringify({ titles }), { status: 200 });
+	} catch (error) {
+		console.error(error);
+		return new Response(JSON.stringify({ error: 'Database error' }), { status: 500 });
+	}
+};

--- a/src/routes/admin/entry/[...slug]/+page.svelte
+++ b/src/routes/admin/entry/[...slug]/+page.svelte
@@ -21,6 +21,8 @@
 	let body: string = $state(entry.body); // 初期値として本文を保持
 	let visibility: 'private' | 'public' = $state(entry.visibility);
 
+	let pageTitles: string[] = $state([]);
+
 	let isDirty = false;
 
 	let currentLinks = extractLinks(entry.body);
@@ -273,10 +275,21 @@
 		return dp[a.length][b.length];
 	}
 
-	// 定期的に本文情報を再取得する。
-	// 他のユーザーが大幅に変更していた場合は警告を表示し、リロードを促す。
-	// TODO: 編集不可状態とする。
+	async function getPageTitles(): Promise<string[]> {
+		const resp = await fetch(`/admin/api/entry/title`, {
+			method: 'GET'
+		});
+		const dat = await resp.json();
+		return dat.titles;
+	}
+
 	onMount(() => {
+		// get page titles
+		setTimeout(async () => (pageTitles = await getPageTitles()), 0);
+
+		// 定期的に本文情報を再取得する。
+		// 他のユーザーが大幅に変更していた場合は警告を表示し、リロードを促す。
+		// TODO: 編集不可状態とする。
 		const interval = setInterval(() => {
 			fetch(`/admin/api/entry/${entry.path}`, {
 				method: 'GET'
@@ -353,6 +366,7 @@
 						onSave={() => {
 							handleUpdateBody();
 						}}
+						{pageTitles}
 					></MarkdownEditor>
 				</div>
 			</form>


### PR DESCRIPTION
Add functionality for autocompletion of internal links in the Markdown editor by fetching page titles from an API endpoint. This enhancement improves user experience by suggesting existing page titles while editing.