### PR TITLE
Refactor feed server to use .dat() for rendering HTML content

### DIFF
--- a/src/routes/feed/+server.ts
+++ b/src/routes/feed/+server.ts
@@ -40,7 +40,7 @@ export const GET: RequestHandler = async () => {
 			.txt(entry.body)
 			.up()
 			.ele('content:encoded')
-			.txt(`<![CDATA[${renderHTMLByEntry(entry, {})}]]>`)
+			.dat(renderHTMLByEntry(entry, {}))
 			.up()
 			.ele('pubDate')
 			.txt(new Date(entry.published_at!).toUTCString())


### PR DESCRIPTION
Update the feed server to utilize the `.dat()` method for rendering HTML, improving the handling of content.

reported by @hsbt