### PR TITLE
Add HTML to Markdown conversion functionality and limit HTML entries retrieval

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
 				"date-fns": "^4.1.0",
 				"dotenv": "^16.4.7",
 				"highlight.js": "^11.11.0",
+				"html-to-md": "^0.8.6",
 				"html-to-text": "^9.0.5",
 				"markdown-it": "^14.1.0",
 				"mysql2": "^3.11.5",
@@ -5195,6 +5196,12 @@
 			"engines": {
 				"node": ">=12.0.0"
 			}
+		},
+		"node_modules/html-to-md": {
+			"version": "0.8.6",
+			"resolved": "https://registry.npmjs.org/html-to-md/-/html-to-md-0.8.6.tgz",
+			"integrity": "sha512-KaRoYxML9AIETfgz5tgI1ioCsT8+skHTIILzrDV66XwCxuWUVjwCcpbnfeUwT9r8VBrfDAa8B5p5b5Pcs9LtRg==",
+			"license": "MIT"
 		},
 		"node_modules/html-to-text": {
 			"version": "9.0.5",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
 		"date-fns": "^4.1.0",
 		"dotenv": "^16.4.7",
 		"highlight.js": "^11.11.0",
+		"html-to-md": "^0.8.6",
 		"html-to-text": "^9.0.5",
 		"markdown-it": "^14.1.0",
 		"mysql2": "^3.11.5",

--- a/src/lib/repository/AdminEntryRepository.ts
+++ b/src/lib/repository/AdminEntryRepository.ts
@@ -417,6 +417,22 @@ export class AdminEntryRepository {
 		);
 		return rows.map((it) => it.title);
 	}
+
+	async getHTMLEntries(): Promise<Entry[]> {
+		const [rows] = await db.query<Entry[] & RowDataPacket[]>(
+			'SELECT * FROM entry WHERE format="html" ORDER BY COALESCE(updated_at, created_at) DESC, path DESC',
+			[]
+		);
+		return rows;
+	}
+
+	async convertToMarkdown(path: string, newBody: string): Promise<void> {
+		await db.query(`UPDATE entry SET body = ?, format = ? WHERE path = ? AND format='html'`, [
+			newBody,
+			'mkdn',
+			path
+		]);
+	}
 }
 
 export type HasDestTitle = {

--- a/src/lib/repository/AdminEntryRepository.ts
+++ b/src/lib/repository/AdminEntryRepository.ts
@@ -420,7 +420,7 @@ export class AdminEntryRepository {
 
 	async getHTMLEntries(): Promise<Entry[]> {
 		const [rows] = await db.query<Entry[] & RowDataPacket[]>(
-			'SELECT * FROM entry WHERE format="html" ORDER BY COALESCE(updated_at, created_at) DESC, path DESC',
+			'SELECT * FROM entry WHERE format="html" ORDER BY COALESCE(updated_at, created_at) DESC, path DESC LIMIT 30',
 			[]
 		);
 		return rows;

--- a/src/routes/admin/entry/[...slug]/+page.svelte
+++ b/src/routes/admin/entry/[...slug]/+page.svelte
@@ -391,6 +391,8 @@
 				</div>
 			{/if}
 
+			<div style="color: green">{entry.format}</div>
+
 			{#if updatedMessage !== ''}
 				<div class="updated-message">
 					{updatedMessage}

--- a/src/routes/admin/htmlmigration/+page.server.ts
+++ b/src/routes/admin/htmlmigration/+page.server.ts
@@ -1,0 +1,10 @@
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ locals }) => {
+	console.log('Loading entry page content!(admin)');
+
+	const entries = await locals.adminEntryRepository.getHTMLEntries();
+	return {
+		entries
+	};
+};

--- a/src/routes/admin/htmlmigration/+page.svelte
+++ b/src/routes/admin/htmlmigration/+page.svelte
@@ -19,16 +19,27 @@
 	}
 
 	function doConvert(entry: Entry) {
+		entries = entries.filter((it: Entry) => it.path !== entry.path);
+
 		fetch(`/admin/htmlmigration/${entry.path}/commit`, {
 			method: 'POST'
 		}).then(() => {
-			entries = entries.filter((it: Entry) => it.path !== entry.path);
 			console.log('DONE');
 		});
 	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key === 'c') {
+			if (entries.length > 0) {
+				console.log(`convert ${entries[0].path}`);
+				doConvert(entries[0]);
+				window.scrollTo({ top: 0, behavior: 'smooth' });
+			}
+		}
+	}
 </script>
 
-<div>
+<div tabindex="0" onkeydown={handleKeydown}>
 	{#each entries as entry}
 		<div class="entry" style={entry.visibility === 'private' ? 'color: gray;' : ''}>
 			<div>

--- a/src/routes/admin/htmlmigration/+page.svelte
+++ b/src/routes/admin/htmlmigration/+page.svelte
@@ -39,7 +39,8 @@
 	}
 </script>
 
-<div tabindex="0" onkeydown={handleKeydown}>
+<!-- eslint-disable-next-line svelte/valid-compile -->
+<div onkeydown={handleKeydown} role="button" tabindex="-1">
 	{#each entries as entry}
 		<div class="entry" style={entry.visibility === 'private' ? 'color: gray;' : ''}>
 			<div>

--- a/src/routes/admin/htmlmigration/+page.svelte
+++ b/src/routes/admin/htmlmigration/+page.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+	import html2md from 'html-to-md';
+	import type { PageData } from './$types';
+	import { error } from '@sveltejs/kit';
+	import { renderHTML } from '$lib/markdown';
+	import { type Entry } from '$lib/db';
+
+	// Get the list of HTML formatted pages.
+	let { data }: { data: PageData } = $props();
+
+	if (!data.entries) {
+		error(500, 'Missing entries data');
+	}
+	let entries: Entry[] = $state(data.entries);
+
+	function handleConvert(event: Event, entry: Entry) {
+		event.preventDefault();
+		doConvert(entry);
+	}
+
+	function doConvert(entry: Entry) {
+		fetch(`/admin/htmlmigration/${entry.path}/commit`, {
+			method: 'POST'
+		}).then(() => {
+			entries = entries.filter((it: Entry) => it.path !== entry.path);
+			console.log('DONE');
+		});
+	}
+</script>
+
+<div>
+	{#each entries as entry}
+		<div class="entry" style={entry.visibility === 'private' ? 'color: gray;' : ''}>
+			<div>
+				<a href="/admin/entry/{entry.path}">Form</a> |
+				<a href="/entry/{entry.path}">Show</a>
+			</div>
+			<div class="title">{entry.title}</div>
+			<div class="side-by-side">
+				<pre class="html">{entry.body}</pre>
+				<pre class="mkdn">{html2md(entry.body)}</pre>
+				<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+				<div class="rendered">{@html renderHTML(html2md(entry.body))}</div>
+			</div>
+
+			<div class="fix">
+				<button onclick={(event) => handleConvert(event, entry)}>Convert!</button>
+			</div>
+		</div>
+	{/each}
+</div>
+
+<style>
+	.entry {
+		border: 1px;
+		margin: 8px;
+	}
+
+	.title {
+		border-bottom: 3px solid darkblue;
+	}
+
+	pre {
+		max-width: 600px;
+		word-break: break-all;
+	}
+
+	button {
+		padding: 8px;
+		border: 1px solid black;
+	}
+
+	.side-by-side .html {
+		float: left;
+		width: 30%;
+		word-break: break-all;
+		overflow-x: scroll;
+	}
+	.side-by-side .mkdn {
+		float: left;
+		width: 30%;
+		word-break: break-all;
+		overflow-x: scroll;
+	}
+	.side-by-side .rendered {
+		float: left;
+		width: 30%;
+		word-break: break-all;
+		overflow-x: scroll;
+	}
+
+	.fix {
+		clear: both;
+	}
+</style>

--- a/src/routes/admin/htmlmigration/+page.svelte
+++ b/src/routes/admin/htmlmigration/+page.svelte
@@ -51,7 +51,7 @@
 				<pre class="html">{entry.body}</pre>
 				<pre class="mkdn">{html2md(entry.body)}</pre>
 				<!-- eslint-disable-next-line svelte/no-at-html-tags -->
-				<div class="rendered">{@html renderHTML(html2md(entry.body))}</div>
+				<div class="rendered">{@html renderHTML(html2md(entry.body), {})}</div>
 			</div>
 
 			<div class="fix">

--- a/src/routes/admin/htmlmigration/[...slug]/commit/+server.ts
+++ b/src/routes/admin/htmlmigration/[...slug]/commit/+server.ts
@@ -1,0 +1,21 @@
+import type { RequestHandler } from '@sveltejs/kit';
+import html2md from 'html-to-md';
+
+export const POST: RequestHandler = async ({ locals, params }) => {
+	const path = params.slug;
+	if (!path) {
+		return new Response(JSON.stringify({ error: 'Missing path' }), { status: 400 });
+	}
+
+	try {
+		const entry = await locals.adminEntryRepository.getEntry(path);
+		const body = html2md(entry.body);
+		console.log(`original=${entry.body} mkdn=${body}`);
+		await locals.adminEntryRepository.convertToMarkdown(path, body);
+
+		return new Response(JSON.stringify(entry), { status: 200 });
+	} catch (error) {
+		console.error(error);
+		return new Response(JSON.stringify({ error: 'Database error' }), { status: 500 });
+	}
+};


### PR DESCRIPTION
Introduce functionality to convert HTML entries to Markdown and limit the retrieval of HTML entries to the latest 30. Enhance keyboard interaction for initiating conversions.