### PR TITLE
Remove unnecessary attributes and enhance RSS feed

### DIFF
--- a/src/lib/server/markdown.ts
+++ b/src/lib/server/markdown.ts
@@ -151,7 +151,11 @@ function buildEntryLinkPlugin(links: { [key: string]: string | null }): (md: Mar
 			const token = tokens[idx];
 			const title = token.content;
 			const pageFound = links[token.content.toLowerCase()];
-			return `<a ${pageFound ? 'href="/entry/' + pageFound + '"' : ''} class="entry-link ${pageFound ? 'found' : 'not-found'}">${md.utils.escapeHtml(title)}</a>`;
+			if (pageFound) {
+				return `<a href="/entry/${pageFound}" class="entry-link found">${md.utils.escapeHtml(title)}</a>`;
+			} else {
+				return `<b>${md.utils.escapeHtml(title)}</b>`;
+			}
 		};
 	};
 }

--- a/src/lib/server/markdown.ts
+++ b/src/lib/server/markdown.ts
@@ -137,10 +137,7 @@ function buildEntryLinkPlugin(links: { [key: string]: string | null }): (md: Mar
 			if (!silent) {
 				const content = state.src.slice(start + 2, end);
 				const token = state.push('entry_link', 'a', 0);
-				token.attrs = [
-					['class', 'entry-link'],
-					['data-title', content]
-				];
+				token.attrs = [['class', 'entry-link']];
 				token.content = content;
 				token.markup = '[[';
 				token.info = '';
@@ -154,7 +151,7 @@ function buildEntryLinkPlugin(links: { [key: string]: string | null }): (md: Mar
 			const token = tokens[idx];
 			const title = token.content;
 			const pageFound = links[token.content.toLowerCase()];
-			return `<a ${pageFound ? 'href="/entry/' + pageFound + '"' : ''} class="entry-link ${pageFound ? 'found' : 'not-found'}" data-title="${md.utils.escapeHtml(title)}">${md.utils.escapeHtml(title)}</a>`;
+			return `<a ${pageFound ? 'href="/entry/' + pageFound + '"' : ''} class="entry-link ${pageFound ? 'found' : 'not-found'}">${md.utils.escapeHtml(title)}</a>`;
 		};
 	};
 }

--- a/src/routes/feed/+server.ts
+++ b/src/routes/feed/+server.ts
@@ -9,13 +9,22 @@ export const GET: RequestHandler = async () => {
 
 	// RSSフィードのヘッダーを作成
 	const feed = create({ version: '1.0' })
-		.ele('rss', { version: '2.0', 'xmlns:content': 'http://purl.org/rss/1.0/modules/content/' })
+		.ele('rss', {
+			version: '2.0',
+			'xmlns:content': 'http://purl.org/rss/1.0/modules/content/',
+			'xmlns:atom': 'http://www.w3.org/2005/Atom'
+		})
 		.ele('channel')
 		.ele('title')
 		.txt("tokuhirom's blog")
 		.up()
 		.ele('link')
 		.txt('https://blog.64p.org')
+		.up()
+		.ele('atom:link')
+		.att('href', 'https://blog.64p.org/feed')
+		.att('rel', 'self')
+		.att('type', 'application/rss+xml')
 		.up()
 		.ele('description')
 		.txt('The latest articles from my blog')


### PR DESCRIPTION
Eliminate the `data-title` attribute from links, ensure links are only created for available pages, and add an `atom:link` element to the RSS feed for better syndication.