### PR TITLE
Use JST and HTML escape descriptions in the feed

### DIFF
--- a/src/routes/feed/+server.ts
+++ b/src/routes/feed/+server.ts
@@ -4,6 +4,12 @@ import { PublicEntryRepository } from '$lib/server/repository/PublicEntryReposit
 import { renderHTMLByEntry } from '$lib/server/markdown';
 import { convert } from 'html-to-text';
 
+function convertJstToUtc(jstDatetime: string): string {
+	// jsDateTime is comming from mysql's DATETIME column.
+	const jstDate = new Date(`${jstDatetime} GMT+0900`);
+	return jstDate.toUTCString();
+}
+
 export const GET: RequestHandler = async () => {
 	const { entries } = await PublicEntryRepository.getPaginatedEntry(1, 30);
 
@@ -58,7 +64,7 @@ export const GET: RequestHandler = async () => {
 			.dat(html)
 			.up()
 			.ele('pubDate')
-			.txt(new Date(entry.published_at!).toUTCString())
+			.txt(convertJstToUtc(entry.published_at!))
 			.up()
 			.ele('guid')
 			.txt(`https://blog.64p.org/entry/${entry.path}`)

--- a/src/routes/feed/+server.ts
+++ b/src/routes/feed/+server.ts
@@ -10,6 +10,15 @@ function convertJstToUtc(jstDatetime: string): string {
 	return jstDate.toUTCString();
 }
 
+function escapeHtml(str: string): string {
+	return str
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#39;');
+}
+
 export const GET: RequestHandler = async () => {
 	const { entries } = await PublicEntryRepository.getPaginatedEntry(1, 30);
 
@@ -58,7 +67,7 @@ export const GET: RequestHandler = async () => {
 			.txt(`https://blog.64p.org/entry/${entry.path}`)
 			.up()
 			.ele('description')
-			.txt(text)
+			.txt(escapeHtml(text))
 			.up()
 			.ele('content:encoded')
 			.dat(html)


### PR DESCRIPTION
Implement conversion of JST to UTC for published dates and escape HTML in feed descriptions to enhance security and data integrity.