### PR TITLE
Fixed the issue where images were overflowing on mobile devices.

### DIFF
--- a/src/routes/entry/[...slug]/page.css
+++ b/src/routes/entry/[...slug]/page.css
@@ -1,4 +1,5 @@
 .entry-body img {
+	width: 100%;
 	max-width: 1000px;
 	margin: auto;
 	display: block;


### PR DESCRIPTION
Checked using the Web Inspector.

|	before	|	after	|
|	:-:	|	:-:	|
|	<img width="165" alt="image" src="https://github.com/user-attachments/assets/c41cfd3c-2fc6-4a54-9bfa-07dfa93d0c6f" />	|	<img width="165" alt="image" src="https://github.com/user-attachments/assets/8c50b454-12a2-4592-ae93-5d5e7c3e3da6" />	|

Powered by [MAT](https://eiryu.com/mat/).